### PR TITLE
Small refactoring to allow reuse

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,9 +15,10 @@ export class HLSPullPush {
   private server: FastifyInstance;
   PLUGINS: Object;
   PAYLOAD_SCHEMAS: any[];
+  SESSIONS: {[sessionId: string]: Session};
 
   constructor() {
-    const SESSIONS = {}; // in memory store
+    this.SESSIONS = {}; // in memory store
     this.PLUGINS = {};
     this.PAYLOAD_SCHEMAS = [];
 
@@ -59,10 +60,11 @@ export class HLSPullPush {
             // Check if string is valid url
             const url = new URL(requestBody.url);
             // Get Plugin from register if valid
-            const requestedPlugin: IOutputPlugin = GetPluginFor(opts.instance, requestBody.output);
+            const requestedPlugin: IOutputPlugin = opts.instance.getPluginFor(requestBody.output);
             if (!requestedPlugin) {
               return reply.code(404).send({ message: `Unsupported Plugin Type '${requestBody.output}'` });
             }
+
             // Generate instance of plugin destination if valid
             let outputDest: IOutputPluginDest;
             try {
@@ -72,22 +74,18 @@ export class HLSPullPush {
               reply.code(404).send(JSON.stringify(err));
             }
 
-            // Create new session and add to local store
-            const session = new Session({
+            const sessionId = opts.instance.startFetcher({
               name: requestBody.name,
               url: url.href,
-              plugin: outputDest,
-              dest: requestBody.output,
+              destPlugin: outputDest,
+              destPluginOpts: requestBody.output,
               concurrency: requestBody["concurrency"] ? requestBody["concurrency"] : null,
               windowSize: requestBody["windowSize"] ? requestBody["windowSize"] : null,
             });
-            // Store Hls recorder in dictionary in-memory
-            SESSIONS[session.sessionId] = session;
-            console.log(`New Fetcher Session Created, id:[${session.sessionId}]`);
 
             reply.code(200).send({
               message: "Created a Fetcher and started pulling from HLS Live Stream",
-              fetcherId: session.sessionId,
+              fetcherId: sessionId,
               requestData: request.body,
             });
           } catch (err) {
@@ -97,13 +95,7 @@ export class HLSPullPush {
       );
       fastify.get("/fetcher", { schema: Schemas("GET/fetcher") }, async (request, reply) => {
         try {
-          // Remove any inactive sessions
-          Object.keys(SESSIONS).map((sessionId) => {
-            if (SESSIONS[sessionId].isActive() === false) {
-              delete SESSIONS[sessionId];
-            }
-          });
-          let activeFetchersList = Object.keys(SESSIONS).map((sessionId) => SESSIONS[sessionId].toJSON());
+          let activeFetchersList = opts.instance.getActiveFetchers();
           reply.code(200).send(activeFetchersList);
         } catch (err) {
           reply.code(500).send(err.message);
@@ -116,22 +108,13 @@ export class HLSPullPush {
           const requestParams: any = request.params;
           const fetcherId = requestParams.fetcherId;
           try {
-            let session = SESSIONS[fetcherId];
-            if (!session) {
+            if (!opts.instance.isValidFetcher(fetcherId)) {
               console.log("Nothing found under specified fetcher id: " + fetcherId);
               return reply.code(404).send({
                 message: `Fetcher with ID: '${fetcherId}' was not found`,
               });
             }
-            console.log("SESSION:", session.toJSON());
-            // Stop recording
-            if (session.isActive()) {
-              await session.StopHLSRecorder();
-            }
-            // Delete Session from store
-            console.log(`Deleting Fetcher Session [ ${fetcherId} ] from Session Storage`);
-            delete SESSIONS[fetcherId];
-
+            await opts.instance.stopFetcher(fetcherId);
             return reply.code(204).send({ message: "Deleted Fetcher Session" });
           } catch (err) {
             reply.code(500).send(err.message);
@@ -143,6 +126,59 @@ export class HLSPullPush {
     this.server.register(apiFetcher, { instance: this, prefix: "/api/v1" });
   }
 
+  startFetcher({ 
+    name, 
+    url, 
+    destPlugin, 
+    destPluginOpts, 
+    concurrency, 
+    windowSize 
+  }: { 
+    name: string; 
+    url: string; 
+    destPlugin: IOutputPluginDest; 
+    destPluginOpts: any; 
+    concurrency?: number; 
+    windowSize?: number 
+  }): string {
+
+    // Create new session and add to local store
+    const session = new Session({ name, url, plugin: destPlugin, dest: destPluginOpts, concurrency, windowSize });
+
+    // Store Hls recorder in dictionary in-memory
+    this.SESSIONS[session.sessionId] = session;
+
+    console.log(`New Fetcher Session Created, id:[${session.sessionId}]`);
+    return session.sessionId;
+  }
+
+  async stopFetcher(fetcherId: string) {
+    let session = this.SESSIONS[fetcherId];
+    console.log("SESSION:", session.toJSON());
+
+    // Stop recording
+    if (session.isActive()) {
+      await session.StopHLSRecorder();
+    }
+    // Delete Session from store
+    console.log(`Deleting Fetcher Session [ ${fetcherId} ] from Session Storage`);
+    delete this.SESSIONS[fetcherId];
+  }
+  
+  isValidFetcher(fetcherId: string): boolean {
+    return (this.SESSIONS[fetcherId] ? true : false);
+  }
+
+  getActiveFetchers() {
+    // Remove any inactive sessions
+    Object.keys(this.SESSIONS).map((sessionId) => {
+      if (this.SESSIONS[sessionId].isActive() === false) {
+        delete this.SESSIONS[sessionId];
+      }
+    });
+    return Object.keys(this.SESSIONS).map((sessionId) => this.SESSIONS[sessionId].toJSON());
+  }
+
   registerPlugin(name: string, plugin: IOutputPlugin): void {
     if (!this.PLUGINS[name]) {
       this.PLUGINS[name] = plugin;
@@ -150,6 +186,21 @@ export class HLSPullPush {
     let pluginPayloadSchema: any = plugin.getPayloadSchema();
     this.PAYLOAD_SCHEMAS.push(pluginPayloadSchema);
     console.log(`Registered output plugin '${name}'`);
+  }
+
+  getPluginFor(name: string): IOutputPlugin {
+    try {
+      const result = this.PLUGINS[name];
+      if (!result) {
+        console.log(
+          `Requested Plugin:'${name}' Not Found Amongst Registered Plugins: [${Object.keys(this.PLUGINS)}]`
+        );
+        return null;
+      }
+      return result;
+    } catch (err) {
+      console.error(err);
+    }  
   }
 
   listen(port) {


### PR DESCRIPTION
This PR includes a small refactoring to be able to reuse some logic without going through the API route. It also moves the SESSION store to be enclosed by the HLSPullPush instance.