### PR TITLE
Enable a demo mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@eyevinn/hls-recorder": "^0.4.0",
         "abort-controller": "^3.0.0",
         "debug": "^4.3.2",
+        "dotenv": "^10.0.0",
         "fastify": "^3.22.1",
         "fastify-cors": "^6.0.2",
         "fastify-swagger": "^4.12.6",
@@ -1370,6 +1371,14 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
+    },
+    "node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/dtrace-provider": {
       "version": "0.8.8",
@@ -4878,6 +4887,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
+    },
+    "dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
     },
     "dtrace-provider": {
       "version": "0.8.8",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@eyevinn/hls-recorder": "^0.4.0",
     "abort-controller": "^3.0.0",
     "debug": "^4.3.2",
+    "dotenv": "^10.0.0",
     "fastify": "^3.22.1",
     "fastify-cors": "^6.0.2",
     "fastify-swagger": "^4.12.6",

--- a/server.ts
+++ b/server.ts
@@ -52,7 +52,7 @@ if (process.env.NODE_ENV === "demo") {
       password: process.env.DEMO_PASSWORD,
     }]
   }, pullPushService.getLogger());
-  const source = new URL("https://demo.vc.eyevinn.technology/channels/eyevinn/master.m3u8");
+  const source = new URL("https://demo.vc.eyevinn.technology/channels/demo/master.m3u8");
   const sessionId = pullPushService.startFetcher({
     name: "demo",
     url: source.href,

--- a/server.ts
+++ b/server.ts
@@ -3,6 +3,8 @@ import { ILogger } from "./types/index";
 import { createLogger, transports, format, Logger } from "winston";
 const { combine, timestamp, printf } = format;
 
+require('dotenv').config();
+
 class MyLogger implements ILogger {
   private logger: Logger;
 
@@ -35,8 +37,27 @@ class MyLogger implements ILogger {
 }
 
 const pullPushService = new HLSPullPush(new MyLogger(process.env.NODE_ENV));
-pullPushService.registerPlugin("mediapackage", new MediaPackageOutput());
+const outputPlugin = new MediaPackageOutput();
+pullPushService.registerPlugin("mediapackage", outputPlugin);
 
 pullPushService.getLogger().info("Running");
 pullPushService.listen(process.env.PORT || 8080);
 
+if (process.env.NODE_ENV === "demo") {
+  // In demo mode we want to automatically start a fetcher
+  const outputDest = outputPlugin.createOutputDestination({
+    ingestUrls: [ {
+      url: process.env.DEMO_CHANNEL,
+      username: process.env.DEMO_USERNAME,
+      password: process.env.DEMO_PASSWORD,
+    }]
+  }, pullPushService.getLogger());
+  const source = new URL("https://demo.vc.eyevinn.technology/channels/eyevinn/master.m3u8");
+  const sessionId = pullPushService.startFetcher({
+    name: "demo",
+    url: source.href,
+    destPlugin: outputDest,
+    destPluginName: "mediapackage"
+  });
+  outputDest.attachSessionId(sessionId);
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -45,7 +45,7 @@ export default function (fastify: FastifyInstance, opts, done) {
           name: requestBody.name,
           url: url.href,
           destPlugin: outputDest,
-          destPluginOpts: requestBody.output,
+          destPluginName: requestBody.output,
           concurrency: requestBody["concurrency"] ? requestBody["concurrency"] : null,
           windowSize: requestBody["windowSize"] ? requestBody["windowSize"] : null,
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,20 +48,20 @@ export class HLSPullPush {
     name, 
     url, 
     destPlugin, 
-    destPluginOpts, 
+    destPluginName, 
     concurrency, 
     windowSize 
   }: { 
     name: string; 
     url: string; 
     destPlugin: IOutputPluginDest; 
-    destPluginOpts: any; 
+    destPluginName: string; 
     concurrency?: number; 
     windowSize?: number 
   }): string {
 
     // Create new session and add to local store
-    const session = new Session({ name, url, plugin: destPlugin, dest: destPluginOpts, concurrency, windowSize });
+    const session = new Session({ name, url, plugin: destPlugin, dest: destPluginName, concurrency, windowSize });
 
     // Store Hls recorder in dictionary in-memory
     this.SESSIONS[session.sessionId] = session;


### PR DESCRIPTION
This PR adds a "demo mode" feature to the reference server implementation. That means that if `NODE_ENV` is set to `demo` it will automatically create a fetcher that pushes HLS to a Media Package destination. The output is configured by the environment variables `DEMO_CHANNEL`, `DEMO_USERNAME`, and `DEMO_PASSWORD`.