### PR TITLE
feat: add event queue

### DIFF
--- a/output_plugins/mediapackage.ts
+++ b/output_plugins/mediapackage.ts
@@ -1,5 +1,5 @@
 import { ILocalFileUpload, IOutputPlugin, IOutputPluginDest, IRemoteFileUpload } from "../types/output_plugin";
-import { ILogger } from "../types/index";
+import { ILogger } from "../types/index";
 import { AuthType, createClient, WebDAVClient } from "webdav";
 import fetch from "node-fetch";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@aws-sdk/client-mediapackage": "^3.41.0",
         "@eyevinn/hls-recorder": "^0.4.2",
         "abort-controller": "^3.0.0",
+        "clone": "^2.1.2",
         "debug": "^4.3.2",
         "dotenv": "^10.0.0",
         "fastify": "^3.22.1",
@@ -31,6 +32,10 @@
       "devDependencies": {
         "@types/node": "^16.11.6",
         "typescript": "^4.4.4"
+      },
+      "engines": {
+        "node": ">=12.0.0",
+        "npm": ">=6.0.0"
       }
     },
     "node_modules/@aws-crypto/ie11-detection": {
@@ -1175,6 +1180,14 @@
         "node": "*"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
@@ -1732,9 +1745,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
-      "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A==",
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
       "funding": [
         {
           "type": "individual",
@@ -4682,6 +4695,11 @@
       "resolved": "https://registry.npmjs.org/chunked-stream/-/chunked-stream-0.0.2.tgz",
       "integrity": "sha1-zPdQmNrb8Ls4/zB+EJWCeAUHk54="
     },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+    },
     "color": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
@@ -5139,9 +5157,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "follow-redirects": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
-      "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A=="
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
     },
     "forever-agent": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
     "type": "git",
     "url": "git+https://github.com/Eyevinn/hls-pull-push.git"
   },
+  "engines": {
+    "npm": ">=6.0.0",
+    "node": ">=12.0.0"
+  },
   "devDependencies": {
     "@types/node": "^16.11.6",
     "typescript": "^4.4.4"
@@ -24,6 +28,7 @@
     "@aws-sdk/client-mediapackage": "^3.41.0",
     "@eyevinn/hls-recorder": "^0.4.2",
     "abort-controller": "^3.0.0",
+    "clone": "^2.1.2",
     "debug": "^4.3.2",
     "dotenv": "^10.0.0",
     "fastify": "^3.22.1",


### PR DESCRIPTION
Fixes #16 
To ensure that emitted events are processed in order and do not overlap,
which could cause uploads in the wrong order (mainly media playlists).

An event queue is introduced in this PR, and the event data processing is
moved out to a separate function