### PR TITLE
feat: multitrack support

### DIFF
--- a/output_plugins/mediapackage.ts
+++ b/output_plugins/mediapackage.ts
@@ -1,6 +1,7 @@
 import { ILocalFileUpload, IOutputPlugin, IOutputPluginDest, IRemoteFileUpload } from "../types/output_plugin";
 import { ILogger } from "../types/index";
 import { AuthType, createClient, WebDAVClient } from "webdav";
+import { URL } from 'url';
 import fetch from "node-fetch";
 
 const { AbortController } = require("abort-controller");

--- a/server.ts
+++ b/server.ts
@@ -1,6 +1,7 @@
 import { HLSPullPush, MediaPackageOutput, S3BucketOutput, VoidOutput } from "./index";
 import { ILogger } from "./types/index";
 import { createLogger, transports, format, Logger } from "winston";
+import { URL } from 'url';
 const { combine, timestamp, printf } = format;
 
 require('dotenv').config();

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,7 @@
 import { Schemas } from "../util/schemas";
 import { IOutputPlugin, IOutputPluginDest } from "../types/output_plugin";
 import { FastifyInstance, FastifyRequest } from "fastify";
+import { URL } from 'url';
 import { HLSPullPush } from "./index";
 
 export default function (fastify: FastifyInstance, opts, done) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "module": "commonjs",
     "esModuleInterop": true,
     "target": "es6",
+    "lib": ["es2021"],
     "moduleResolution": "node",
     "sourceMap": true,
     "resolveJsonModule": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "esModuleInterop": true,
     "target": "es6",
-    "lib": ["es2021"],
+    "lib": ["es2021", "dom"],
     "moduleResolution": "node",
     "sourceMap": true,
     "resolveJsonModule": true,

--- a/util/handleSegments.ts
+++ b/util/handleSegments.ts
@@ -84,7 +84,9 @@ export const GetOnlyNewestSegments = (
 };
 
 /* These URLs will be what is written in the playlist manifest we later generate */
-export const ReplaceSegmentURLs = (segments: ISegments): ISegments => {
+export const GenerateSegmentNameMap = (segments: ISegments): Map<string, string> => {
+
+  const nameMap = new Map<string, string>();
   // Before altering key values - Make deep copy.
   segments = JSON.parse(JSON.stringify(segments));
 
@@ -97,8 +99,9 @@ export const ReplaceSegmentURLs = (segments: ISegments): ISegments => {
     for (let i = 0; i < segListSize; i++) {
       const segmentUri: string = segments["video"][bw].segList[i].uri;
       if (segmentUri) {
-        const replacementUrl = `channel_${bw}_${segments["video"][bw].segList[i].index}.ts`; // assuming input is MPEG TS-file.
-        segments["video"][bw].segList[i].uri = replacementUrl;
+        const fileExtension = ".ts" // assuming input is MPEG TS-file.
+        const fileName = `channel_${bw}_${segments["video"][bw].segList[i].index}${fileExtension}`
+        nameMap.set(segmentUri, fileName);
       }
     }
   });
@@ -112,8 +115,9 @@ export const ReplaceSegmentURLs = (segments: ISegments): ISegments => {
         for (let i = 0; i < segListSize; i++) {
           const segmentUri = segments["audio"][group][lang].segList[i].uri;
           if (segmentUri) {
-            const replacementUrl = `channel_a-${group}-${lang}_${segments["audio"][group][lang].segList[i].index}.aac`; // assuming input is AAC.
-            segments["audio"][group][lang].segList[i].uri = replacementUrl;
+            const fileExtension = ".aac" // assuming input is AAC.
+            const fileName = `channel_a-${group}-${lang}_${segments["audio"][group][lang].segList[i].index}${fileExtension}`;
+            nameMap.set(segmentUri, fileName);
           }
         }
       }
@@ -129,13 +133,14 @@ export const ReplaceSegmentURLs = (segments: ISegments): ISegments => {
         for (let i = 0; i < segListSize; i++) {
           const segmentUri = segments["subtitle"][group][lang].segList[i].uri;
           if (segmentUri) {
-            const replacementUrl = `channel_s-${group}-${lang}_${segments["subtitle"][group][lang].segList[i].index}.vtt`; // assuming input is WEBVTT.
-            segments["subtitle"][group][lang].segList[i].uri = replacementUrl;
+            const fileExtension = ".vtt" // assuming input is WEBVTT.
+            const fileName = `channel_s-${group}-${lang}_${segments["subtitle"][group][lang].segList[i].index}${fileExtension}`;
+            nameMap.set(segmentUri, fileName);
           }
         }
       }
     });
   }
-  return segments;
+  return nameMap;
 };
 

--- a/util/handleSegments.ts
+++ b/util/handleSegments.ts
@@ -112,7 +112,7 @@ export const ReplaceSegmentURLs = (segments: ISegments): ISegments => {
         for (let i = 0; i < segListSize; i++) {
           const segmentUri = segments["audio"][group][lang].segList[i].uri;
           if (segmentUri) {
-            const replacementUrl = `channel_a-${group}-${lang}_${segments["audio"][group][lang].segList[i].index}.ts`; // assuming input is MPEG TS-file.
+            const replacementUrl = `channel_a-${group}-${lang}_${segments["audio"][group][lang].segList[i].index}.aac`; // assuming input is AAC.
             segments["audio"][group][lang].segList[i].uri = replacementUrl;
           }
         }
@@ -129,7 +129,7 @@ export const ReplaceSegmentURLs = (segments: ISegments): ISegments => {
         for (let i = 0; i < segListSize; i++) {
           const segmentUri = segments["subtitle"][group][lang].segList[i].uri;
           if (segmentUri) {
-            const replacementUrl = `channel_s-${group}-${lang}_${segments["subtitle"][group][lang].segList[i].index}.ts`; // assuming input is MPEG TS-file.
+            const replacementUrl = `channel_s-${group}-${lang}_${segments["subtitle"][group][lang].segList[i].index}.vtt`; // assuming input is WEBVTT.
             segments["subtitle"][group][lang].segList[i].uri = replacementUrl;
           }
         }

--- a/util/handleSegments.ts
+++ b/util/handleSegments.ts
@@ -83,7 +83,7 @@ export const GetOnlyNewestSegments = (
   return newestSegments;
 };
 
-/* These URLs will be what is written in the playlist manifest we later generate */
+/* Generate mapings of URLs to file names, will be used for writing playlist manifests and handling the files */
 export const GenerateSegmentNameMap = (segments: ISegments): Map<string, string> => {
 
   const nameMap = new Map<string, string>();

--- a/util/session.ts
+++ b/util/session.ts
@@ -223,7 +223,8 @@ export class Session {
           .replaceAll("_", "-")
           .replaceAll("master-audiotrack-", "channel_a-")
           .replaceAll("master-subtrack-", "channel_s-")
-          .replaceAll("master", "channel_");
+          .replaceAll("master", "channel_")
+          .replaceAll("channel_a-audio-", "channel_a-audio_");
 
         if (this.masterM3U8 !== "") {
           let result = await this.outputDestination.uploadMediaPlaylist({

--- a/util/session.ts
+++ b/util/session.ts
@@ -217,7 +217,7 @@ export class Session {
     if (!this.masterM3U8) {
       try {
         debug(`[${this.sessionId}]: Trying to upload multivariant manifest...`);
-        this.masterM3U8 = this.hlsrecorder.masterManifest.replace(/master/g, "channel_");
+        this.masterM3U8 = this.hlsrecorder.masterManifest.replaceAll("master", "channel_");
         if (this.masterM3U8 !== "") {
           let result = await this.outputDestination.uploadMediaPlaylist({
             fileName: "channel.m3u8",
@@ -538,7 +538,7 @@ export class Session {
         allSegments: segments,
       };
       GenerateMediaM3U8(parseInt(bw), generatorOptions).then((playlistM3u8: string) => {
-        const playlistToBeUploaded: string = playlistM3u8.replace(/master/g, "channel");
+        const playlistToBeUploaded: string = playlistM3u8.replaceAll("master", "channel");
         let name;
         if (multiVariantExists) {
           name = `channel_${bw}.m3u8`;

--- a/util/session.ts
+++ b/util/session.ts
@@ -314,6 +314,7 @@ export class Session {
         // Make Segment Urls formatted and ready for Manifest Generation
         SegmentsWithNewURL = ReplaceSegmentURLs(this.collectedSegments);
         // Upload Recording Playlist Manifest to S3 Bucket
+        debug(`[${this.sessionId}]: SEGMENT URL RENAME MAP:`);
         let tasksManifest = await this._UploadAllManifest(
           this.m3u8Queue,
           SegmentsWithNewURL,
@@ -429,8 +430,10 @@ export class Session {
     }
     return -1;
   }
-
-  private async _UploadAllSegments(taskQueue: queueAsPromised<SegmentTask>, segments: ISegments): Promise<any[]> {
+  private async _UploadAllSegments(
+    taskQueue: queueAsPromised<SegmentTask>,
+    segments: ISegments
+  ): Promise<any[]> {
     const tasks = [];
     const bandwidths = Object.keys(segments["video"]);
     const groupsAudio = Object.keys(segments["audio"]);
@@ -501,7 +504,6 @@ export class Session {
       }
     }
     */
-
     return tasks;
   }
 
@@ -557,9 +559,7 @@ export class Session {
       });
     });
     /*
-
     TODO: Support Multi-tracks
-
     // For Demux Audio
     if (groupsAudio.length > 0) {
       groupsAudio.forEach(async (group) => {
@@ -590,12 +590,12 @@ export class Session {
         const languages = Object.keys(segments["subtitle"][group]);
         for (let k = 0; k < languages.length; k++) {
           const lang = languages[k];
-      let generatorOptions = {
-        mseq: m3uPlaylistData.mseq,
-        dseq: m3uPlaylistData.dseq,
-        targetDuration: m3uPlaylistData.targetDur,
-        allSegments: segments,
-      };
+          let generatorOptions = {
+            mseq: m3uPlaylistData.mseq,
+            dseq: m3uPlaylistData.dseq,
+            targetDuration: m3uPlaylistData.targetDur,
+            allSegments: segments,
+          };
           GenerateSubtitleM3U8(group, lang, generatorOptions).then((playlistM3u8) => {
             const name = `master-sub_${group}_${lang}`;
             let item = {
@@ -785,7 +785,6 @@ export class Session {
         }
       });
       /* TODO: Support MultiTrack
-
       
       // Shifting on all audio lists
       groups.forEach((group) => {
@@ -803,7 +802,6 @@ export class Session {
           const releasedSegmentItem = Segments["subtitle"][group][lang].segList.shift();
         }
       });
-
       */
     }
 


### PR DESCRIPTION
This PR is mostly the same changes as #26 but I rewrote the semantics a bit because the old ReplaceSegmentURLs method would overwrite the urls we want to fetch with the names we want to use, so we couldn't full use it and had to duplicate the same logic (and this created an error because the file names generated in one place didn't match the other).

Also made some other small cleanup, fixes and optimizations.

The file extensions are still hard coded.

I have verified with the s3 plugin that the file names seems to match now, but I couldn't figure out how to use the MediaPackage.